### PR TITLE
Fix Windows build issues in CI workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -231,20 +231,41 @@ jobs:
         $exePath = "build\${{ inputs.build_type }}\xdelta3.exe"
         Copy-Item $exePath -Destination $artifactsDir
 
-        # Create README and process artifacts using the unified script
-        Write-Host "Processing artifacts using unified script..."
-
-        # Use bash to run the unified script
-        bash -c "chmod +x '${{ github.workspace }}/.github/scripts/unified-artifacts.sh' && '${{ github.workspace }}/.github/scripts/unified-artifacts.sh' create windows '$artifactsDir' '${{ matrix.arch }}'"
-
-        # Verify the README was created
+        # Create README manually to avoid path issues
+        Write-Host "Creating README.txt manually..."
         $readmePath = Join-Path -Path $artifactsDir -ChildPath "README.txt"
-        if (Test-Path $readmePath) {
-            Write-Host "README.txt verified at: $readmePath"
-            Get-Content $readmePath | Select-Object -First 3 | ForEach-Object { Write-Host "  $_" }
-        } else {
-            Write-Host "WARNING: README.txt not found after running script"
-        }
+        $readmeContent = @'
+Xdelta3 Windows Binary
+======================
+
+This package contains the xdelta3 command-line utility for Windows.
+
+Command Line Syntax
+-------------------
+
+make patch:
+
+  xdelta3.exe -e -s old_file new_file delta_file
+
+apply patch:
+
+  xdelta3.exe -d -s old_file delta_file decoded_new_file
+
+standard options:
+   -0 .. -9     compression level
+   -c           use stdout
+   -d           decompress
+   -e           compress
+   -f           force (overwrite, ignore trailing garbage)
+   -h           show help
+   -q           be quiet
+   -v           be verbose (max 2)
+   -V           show version
+
+For full documentation, run: xdelta3.exe --help
+'@
+        Set-Content -Path $readmePath -Value $readmeContent
+        Write-Host "README.txt created manually"
 
         # Create archive if requested
         if ("${{ inputs.create_archives }}" -eq "true") {

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -81,14 +81,14 @@ jobs:
         token: ${{ github.token }}
         github-binarycache: true
         cache-key: vcpkg-${{ runner.os }}-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json') }}
+        no-install: true  # Don't install dependencies yet, we'll do it manually
       continue-on-error: true
 
-    # Retry vcpkg setup if it fails
-    - name: Retry vcpkg setup if needed
-      if: steps.vcpkg.outcome != 'success'
+    # Install vcpkg dependencies manually
+    - name: Install vcpkg dependencies
       shell: pwsh
       run: |
-        Write-Host "First vcpkg setup attempt failed, retrying..."
+        Write-Host "Installing vcpkg dependencies manually..."
 
         # Try to install dependencies directly
         $maxAttempts = 3
@@ -98,8 +98,9 @@ jobs:
           Write-Host "Attempt $attempt of $maxAttempts to install vcpkg dependencies"
 
           try {
-            # Install liblzma directly
-            vcpkg install liblzma:${{ matrix.triplet }} --triplet=${{ matrix.triplet }}
+            # Install liblzma directly with verbose output
+            Write-Host "Installing liblzma:${{ matrix.triplet }}"
+            vcpkg install liblzma:${{ matrix.triplet }} --triplet=${{ matrix.triplet }} --debug
             if ($LASTEXITCODE -eq 0) {
               Write-Host "✅ Successfully installed dependencies"
               break
@@ -118,6 +119,10 @@ jobs:
           Write-Host "⚠️ Failed to install dependencies after $maxAttempts attempts"
           # Continue anyway, CMake might be able to find system libraries
         }
+
+        # List installed packages for debugging
+        Write-Host "Listing installed vcpkg packages:"
+        vcpkg list
 
     - name: Configure CMake with retry
       shell: pwsh


### PR DESCRIPTION
## Problem

The current CI workflow fails during Windows builds with the error:

```
No files were found with the provided path: artifacts/windows-x64. No artifacts will be uploaded.
```

## Root Cause

Path format incompatibility when using bash to call `unified-artifacts.sh` script from Windows PowerShell. Windows uses backslashes `\` while bash requires forward slashes `/`.

## Solution

1. Removed dependency on `unified-artifacts.sh` script, creating README files directly in PowerShell
2. Used PowerShell multi-line string syntax `@'...'@` to create README content
3. Simplified artifact handling logic to avoid cross-platform path issues
4. Improved vcpkg dependency installation process with additional debugging information

This fix should resolve the path issues in Windows builds, allowing the CI workflow to complete successfully.