### PR TITLE
Fix git-tree calculation in vcpkg registry CI workflows

### DIFF
--- a/.github/scripts/update-vcpkg-registry.sh
+++ b/.github/scripts/update-vcpkg-registry.sh
@@ -121,8 +121,8 @@ if [[ "$DRY_RUN" == "false" ]]; then
   # Stage the changes to get the correct git-tree
   git add vcpkg-registry/
 
-  # Get the git-tree hash for the vcpkg-registry directory
-  GIT_TREE=$(git write-tree --prefix=vcpkg-registry/)
+  # Get the git-tree hash for the ports/xdelta directory
+  GIT_TREE=$(git write-tree --prefix=vcpkg-registry/ports/xdelta/)
   echo "Git-tree hash: $GIT_TREE"
 
   # Update git-tree in versions/x-/xdelta.json

--- a/.github/workflows/vcpkg-registry-update.yml
+++ b/.github/workflows/vcpkg-registry-update.yml
@@ -324,8 +324,8 @@ jobs:
         # Stage the changes to get the correct git-tree
         git add vcpkg-registry/
 
-        # Get the git-tree hash for the vcpkg-registry directory
-        GIT_TREE=$(git write-tree --prefix=vcpkg-registry/)
+        # Get the git-tree hash for the ports/xdelta directory
+        GIT_TREE=$(git write-tree --prefix=vcpkg-registry/ports/xdelta/)
         echo "Git-tree hash: $GIT_TREE"
 
         # Update git-tree in versions/x-/xdelta.json


### PR DESCRIPTION
## 🔧 Fix git-tree calculation in vcpkg registry CI workflows

This PR fixes the critical git-tree calculation error in the vcpkg registry CI workflows that was causing hash mismatches and preventing downstream projects (like EACopy) from successfully installing the xdelta dependency.

### 🐛 Problem
The CI workflows were calculating git-tree hash for the entire `vcpkg-registry/` directory instead of the specific `vcpkg-registry/ports/xdelta/` directory, causing:
- Incorrect git-tree hashes in the vcpkg registry
- vcpkg installation failures in downstream projects
- EACopy build failures due to xdelta dependency issues

### ✅ Solution
Fixed git-tree calculation in two key files:

1. **`.github/workflows/vcpkg-registry-update.yml`**
   - Changed from: `git write-tree --prefix=vcpkg-registry/`
   - Changed to: `git write-tree --prefix=vcpkg-registry/ports/xdelta/`

2. **`.github/scripts/update-vcpkg-registry.sh`**
   - Changed from: `git write-tree --prefix=vcpkg-registry/`
   - Changed to: `git write-tree --prefix=vcpkg-registry/ports/xdelta/`

### 🧪 Verification
- ✅ Verified different hash values between incorrect and correct calculations
- ✅ Updated vcpkg-registry branch with correct git-tree hash
- ✅ JSON format validation passed
- ✅ All changes committed and pushed

### 📊 Hash Comparison
- **Incorrect calculation**: `54ae4b633eebb54151868db1b67aa0cc7122879d`
- **Correct calculation**: `a1a57db88727b630e1b25d61fef3b7cae458fa1e`

### 🎯 Impact
This fix ensures:
- Future CI runs will generate correct git-tree hashes
- vcpkg registry will have accurate hash references
- Downstream projects can successfully install xdelta dependency
- EACopy and other projects can build with xdelta support

### 📋 Related Tasks
This PR addresses the tasks outlined in `XDELTA_REGISTRY_FIX_TASKS.md`:
- ✅ Task 2: Fix vcpkg-registry-update.yml workflow
- ✅ Task 3: Fix update-vcpkg-registry.sh script
- ✅ Task 4: Manual fix of current vcpkg-registry branch git-tree
- ✅ Task 5: Commit all fixes

### 🔍 Testing Needed
After merge, please test:
1. Create a test PR to trigger CI and verify correct git-tree calculation
2. Test xdelta installation in EACopy project: `vcpkg install xdelta --triplet=x64-windows`
3. Verify EACopy builds successfully with xdelta dependency