### PR TITLE
Fix vcpkg portfile.cmake path issue

### DIFF
--- a/vcpkg-registry/ports/xdelta/portfile.cmake
+++ b/vcpkg-registry/ports/xdelta/portfile.cmake
@@ -17,9 +17,9 @@ vcpkg_extract_source_archive(
 
 # Install binaries
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    set(ARCH_DIR "${SOURCE_PATH}/${VERSION}/x64-windows")
+    set(ARCH_DIR "${SOURCE_PATH}/xdelta-${VERSION}-windows/${VERSION}/x64-windows")
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    set(ARCH_DIR "${SOURCE_PATH}/${VERSION}/x86-windows")
+    set(ARCH_DIR "${SOURCE_PATH}/xdelta-${VERSION}-windows/${VERSION}/x86-windows")
 else()
     message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()


### PR DESCRIPTION
## Problem
The vcpkg registry portfile.cmake had incorrect path configuration that was preventing proper package installation.

## Solution
Fixed the ARCH_DIR path configuration in portfile.cmake:
- Changed from `${SOURCE_PATH}/${VERSION}/x64-windows` to `${SOURCE_PATH}/xdelta-${VERSION}-windows/${VERSION}/x64-windows`
- Changed from `${SOURCE_PATH}/${VERSION}/x86-windows` to `${SOURCE_PATH}/xdelta-${VERSION}-windows/${VERSION}/x86-windows`

## Impact
- Resolves vcpkg registry path issue
- Enables proper xdelta dependency installation via vcpkg
- Paths now correctly match the actual archive structure from GitHub releases

## Testing
- [x] Path structure verified against release archive format
- [x] Changes committed and pushed to new branch

This fix allows users to successfully install xdelta via vcpkg registry without path-related errors.